### PR TITLE
Remove zfs-localpv images from docker images to be added to k3s package

### DIFF
--- a/scripts/airgap/image-list.txt
+++ b/scripts/airgap/image-list.txt
@@ -1,10 +1,3 @@
 docker.io/rancher/coredns-coredns:1.6.9
 docker.io/rancher/klipper-lb:v0.1.2
 docker.io/rancher/pause:3.1
-quay.io/k8scsi/csi-resizer:v0.4.0
-quay.io/k8scsi/csi-snapshotter:v2.0.1
-quay.io/k8scsi/snapshot-controller:v2.0.1
-quay.io/k8scsi/csi-provisioner:v1.6.0
-quay.io/openebs/zfs-driver:ci
-quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
-debian:testing-slim


### PR DESCRIPTION
We don't use zfs-localpv for charts we support. Users looking to use it can pull it from network automatically when they use it. This should reduce image size by a considerable size, almost ~100-200MB.

