### PR TITLE
Update containerd digest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace (
 	github.com/Mirantis/cri-dockerd => github.com/k3s-io/cri-dockerd v0.2.4-0.20220826195316-d6cb76f15a6a
 	github.com/cloudnativelabs/kube-router => github.com/k3s-io/kube-router v1.5.1-0.20220630214451-a43bcd8511d2
 	github.com/containerd/cgroups => github.com/containerd/cgroups v1.0.1
-	github.com/containerd/containerd => github.com/truenas/containerd v1.5.14-0.20221215222106-307e0eb8767e
+	github.com/containerd/containerd => github.com/truenas/containerd v1.5.14-0.20230103172058-85ecc757e559
 	github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
 	github.com/docker/distribution => github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/docker => github.com/docker/docker v20.10.12+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1128,8 +1128,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uLFQ=
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
-github.com/truenas/containerd v1.5.14-0.20221215222106-307e0eb8767e h1:NNJmUU99dHMyaA49nuZWaTQjlApz9Pon5rNOsamw1i4=
-github.com/truenas/containerd v1.5.14-0.20221215222106-307e0eb8767e/go.mod h1:zUdlwwmj8Xwd65Wz+vPGjonBN3FFAkSGwRloPefnNN4=
+github.com/truenas/containerd v1.5.14-0.20230103172058-85ecc757e559 h1:yGVOJLBqRxWvjyChFuXyQbDf50bvWo9WBOX8DBs9i4A=
+github.com/truenas/containerd v1.5.14-0.20230103172058-85ecc757e559/go.mod h1:zUdlwwmj8Xwd65Wz+vPGjonBN3FFAkSGwRloPefnNN4=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=


### PR DESCRIPTION
## Context

Containerd has been changed to use middleware for validation of host paths and those changes should be reflected now in k3s so it pulls the latest changes from containerd.